### PR TITLE
Trim trailing spaces from post titles

### DIFF
--- a/pkg/fanbox/storage.go
+++ b/pkg/fanbox/storage.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/hareku/go-filename"
@@ -100,7 +101,7 @@ func (s *localStorage) makeFileName(post Post, order int, img Image) string {
 		panic(fmt.Errorf("failed to parse post published date time %s: %w", post.PublishedDateTime, err))
 	}
 
-	title := filename.EscapeString(post.Title, "-")
+	title := strings.TrimSpace(filename.EscapeString(post.Title, "-"))
 
 	if s.dirByPost {
 		// [SaveDirectory]/[UserID]/2006-01-02-[Post Title]/[Order]-[Image ID].[Image Extension]


### PR DESCRIPTION
This avoids errors when trying to open a file in the post directory, since creating a folder with a trailing space on Windows will result in it being trimmed. For example:

![image](https://user-images.githubusercontent.com/10457847/131236866-d720b63b-c262-4008-a42b-552c54785ad0.png)
