### PR TITLE
Prevent Crash when Missing Image/File IDs

### DIFF
--- a/pkg/fanbox/client.go
+++ b/pkg/fanbox/client.go
@@ -71,6 +71,11 @@ func (c *Client) Run(ctx context.Context, creatorID string) error {
 					return fmt.Errorf("unsupported asset type: %+v", d)
 				}
 
+				if d.GetID() == "" {
+					c.Logger.Infof("Can't download %dth %s of %q: bad URL", order, assetType, post.Title)
+					continue
+				}
+
 				isDownloaded, err := c.Storage.Exist(post, order, d)
 				if err != nil {
 					return fmt.Errorf("failed to check whether does %s exist: %w", assetType, err)


### PR DESCRIPTION
#25 appears to happen because the API can give a response back that has an image block with an `imageId` that isn't present in the `imageMap`, so the `Downloadable` object representing it has the zero string for a URL, among other properties. This PR adds a check to see if a `Downloadable` has a blank ID, and reports to the user that its URL is unusable if that's the case.