### PR TITLE
fix: skip failing downloads instead of exiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The latest binary can be downloaded [here](https://github.com/hareku/fanbox-dl/r
 | dir-by-post | Separates content saved into directories based on the title of the post. <br>Stored inside the plan directory when accompanied by the `dir-by-plan` flag. | `--dir-by-post` | `false` |
 | all | Will ensure that all content is downloaded from creators. <br>Will also redownload content that might already be present locally. | `--all` | `false` |
 | skip-files | Will skip downloading non-image files from creators. | `--skip-files` | `false` |
+| skip-on-error | Will skip downloading instead of exiting when an error occurs. | `--skip-on-error` | `false` |
 | dry-run | Will skip downloading all content from creators. | `--dry-run` | `false` |
 | verbose | Gives more detailed information about commands being executed by the application. <br>Useful for debugging errors. | `--verbose` | `false` |
 | save-dir | Root directory to save content. <br>Put directory in double quotes `"` if it contains spaces. <br> Supports relative and absolute directories. | `--savedir ./content` | `./images` |

--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -99,6 +99,11 @@ var verboseFlag = &cli.BoolFlag{
 	Value: false,
 	Usage: "Whether to output debug logs.",
 }
+var skipOnErrorFlag = &cli.BoolFlag{
+	Name:  "skip-on-error",
+	Value: false,
+	Usage: "Whether to skip downloading instead of exiting when an error occurred.",
+}
 
 var app = &cli.App{
 	Name:  "fanbox-dl",
@@ -118,6 +123,7 @@ var app = &cli.App{
 		skipFiles,
 		dryRunFlag,
 		verboseFlag,
+		skipOnErrorFlag,
 	},
 	Action: func(c *cli.Context) error {
 		logger := fanbox.NewLogger(&fanbox.NewLoggerInput{
@@ -148,6 +154,7 @@ var app = &cli.App{
 			CheckAllPosts:     c.Bool(allFlag.Name),
 			DryRun:            c.Bool(dryRunFlag.Name),
 			SkipFiles:         c.Bool(skipFiles.Name),
+			SkipOnError:       c.Bool(skipOnErrorFlag.Name),
 			OfficialAPIClient: api,
 			Storage: &fanbox.LocalStorage{
 				SaveDir:   c.String(saveDirFlag.Name),

--- a/pkg/fanbox/client.go
+++ b/pkg/fanbox/client.go
@@ -18,6 +18,7 @@ type Client struct {
 	CheckAllPosts     bool
 	DryRun            bool
 	SkipFiles         bool
+	SkipOnError       bool
 	OfficialAPIClient *OfficialAPIClient
 	Storage           *LocalStorage
 	Logger            *Logger
@@ -109,8 +110,11 @@ func (c *Client) Run(ctx context.Context, creatorID string) error {
 
 				c.Logger.Infof("Downloading %dth %s of %s\n", order, assetType, post.Title)
 				if err := c.downloadWithRetry(ctx, post, order, d); err != nil {
-					c.Logger.Errorf("Download error; skipping file. %s", err.Error())
-					continue
+					if c.SkipOnError {
+						c.Logger.Errorf("Skip downloading, because of an error: %s", err.Error())
+						continue
+					}
+					return fmt.Errorf("download: %w", err)
 				}
 			}
 		}

--- a/pkg/fanbox/client.go
+++ b/pkg/fanbox/client.go
@@ -109,7 +109,8 @@ func (c *Client) Run(ctx context.Context, creatorID string) error {
 
 				c.Logger.Infof("Downloading %dth %s of %s\n", order, assetType, post.Title)
 				if err := c.downloadWithRetry(ctx, post, order, d); err != nil {
-					return fmt.Errorf("download with retry: %w", err)
+					c.Logger.Errorf("Download error; skipping file. %s", err.Error())
+					continue
 				}
 			}
 		}


### PR DESCRIPTION
Addresses issues [#36](https://github.com/hareku/fanbox-dl/issues/36), [#49](https://github.com/hareku/fanbox-dl/issues/49).

When downloads fail, they are now skipped instead of exiting the program, which allows remaining downloads to continue.

Example failure scenario when downloading a public image from user `kopam`; pictured is the existing behaviour of v0.23.2, compared with the behaviour of this change:

![skip-failures-compare](https://github.com/user-attachments/assets/48b7fcb0-e56a-489e-931e-bfcbb3ae69ad)
