### PR TITLE
fix: expand scope of skip-on-error flag

### DIFF
--- a/pkg/fanbox/client.go
+++ b/pkg/fanbox/client.go
@@ -127,6 +127,10 @@ func (c *Client) handlePost(ctx context.Context, item Post) error {
 			if errors.Is(err, errAlreadyDownloaded) && c.CheckAllPosts {
 				continue
 			}
+			if c.SkipOnError {
+				slog.ErrorContext(ctx, "Skip downloading due to error", "error", err)
+				continue
+			}
 			return fmt.Errorf("handle %s: %w", assetType, err)
 		}
 	}
@@ -168,10 +172,6 @@ func (c *Client) handleAsset(ctx context.Context, post Post, order int, d Downlo
 
 	slog.InfoContext(ctx, "Downloading")
 	if err := c.downloadWithRetry(ctx, post, order, d); err != nil {
-		if c.SkipOnError {
-			slog.ErrorContext(ctx, "Skip downloading due to error", "error", err)
-			return nil
-		}
 		return fmt.Errorf("download: %w", err)
 	}
 

--- a/pkg/fanbox/client.go
+++ b/pkg/fanbox/client.go
@@ -59,6 +59,10 @@ func (c *Client) Run(ctx context.Context, creatorID string) error {
 				slog.DebugContext(ctx, "No more new assets")
 				return nil
 			}
+			if c.SkipOnError {
+				slog.ErrorContext(ctx, "Skip downloading page due to error", "error", err)
+				continue
+			}
 			return fmt.Errorf("handle page: %w", err)
 		}
 	}
@@ -68,6 +72,10 @@ func (c *Client) Run(ctx context.Context, creatorID string) error {
 func (c *Client) handlePage(ctx context.Context, content *ListCreatorResponse) error {
 	for _, item := range content.Body {
 		if err := c.handlePost(ctx, item); err != nil {
+			if c.SkipOnError {
+				slog.ErrorContext(ctx, "Skip downloading post due to error", "error", err)
+				continue
+			}
 			return fmt.Errorf("handle post: %w", err)
 		}
 	}


### PR DESCRIPTION
Provides a workaround for [#54](https://github.com/hareku/fanbox-dl/issues/54).

`skip-on-error` flag covers all errors thrown while looping through assets, posts, and pages.

I couldn't think of a way to easily add unit test cases, so here's a manual test with some example hardcoded errors, using a modified build (these are _not_ committed in this PR):

![skip-on-error-expand](https://github.com/user-attachments/assets/6c3b3a98-a6a7-4922-8337-56309d7cc404)
