### PR TITLE
fix: add request header `Referer` to reduce 403 error

### DIFF
--- a/pkg/fanbox/official_api_client.go
+++ b/pkg/fanbox/official_api_client.go
@@ -31,6 +31,7 @@ func (c *OfficialAPIClient) Request(ctx context.Context, method string, url stri
 	req = req.WithContext(ctx)
 	req.Header.Set("Cookie", c.Cookie)
 	req.Header.Set("Origin", "https://www.fanbox.cc") // If Origin header is not set, FANBOX returns HTTP 400 error.
+	req.Header.Set("Referer", "https://www.fanbox.cc/")
 	req.Header.Set("User-Agent", c.UserAgent)
 	req.Header.Set("Accept", "application/json, text/plain, */*")
 	req.Header.Set("Accept-Encoding", "gzip")


### PR DESCRIPTION
ref: #59

After I added the `Referer: https://www.fanbox.cc/` header to the `OfficialAPIClient.Request()` function, the frequency of `HTTP 403` responses significantly decreased. Previously, almost all of my requests to `GET /post.info` encountered HTTP 403 responses.

I used a test code to specifically target the `/post.info` request. Alongside receiving the HTTP 403 response, I also received a descriptive error page which clearly stated the message: `あなたの環境からはFANBOXにアクセスできません。`. Therefore, I think recent FANBOX API changes now require additional parameters for request validation, especially these APIs appear to be primarily designed for website usage.

After comparing this with the network requests made by the actual website, I identified the `Referer` header as a likely critical parameter. Consequently, I added the `Referer` to the `OfficialAPIClient.Request()` function. This change should theoretically emulate browser behavior more closely.