### PR TITLE
Add timeout flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The latest binary can be downloaded [here](https://github.com/hareku/fanbox-dl/r
 | save-dir | Root directory to save content. <br>Put directory in double quotes `"` if it contains spaces. <br> Supports relative and absolute directories. | `--save-dir ./content` | `./images` |
 | user-agent | User agent to use for requests. | `--user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"` | `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3` |
 | remove-unprintable-chars | Removes unprintable characters from the file name. In some environments, unprintable characters are not allowed in file names. | `--remove-unprintable-chars` | `false` |
+| start-date | Only download posts published on or after this date. Format: YYYY-MM-DD | `--start-date 2023-01-01` | `NULL` |
+| end-date | Only download posts published on or before this date. Format: YYYY-MM-DD | `--end-date 2023-12-31` | `NULL` |
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The latest binary can be downloaded [here](https://github.com/hareku/fanbox-dl/r
 | save-dir | Root directory to save content. <br>Put directory in double quotes `"` if it contains spaces. <br> Supports relative and absolute directories. | `--save-dir ./content` | `./images` |
 | user-agent | User agent to use for requests. | `--user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"` | `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3` |
 | remove-unprintable-chars | Removes unprintable characters from the file name. In some environments, unprintable characters are not allowed in file names. | `--remove-unprintable-chars` | `false` |
+| request-timeout | Set timeout in seconds for each requests, useful for downloading large files | `--request-timeout` | `30` |
 | start-date | Only download posts published on or after this date. Format: YYYY-MM-DD | `--start-date 2023-01-01` | `NULL` |
 | end-date | Only download posts published on or before this date. Format: YYYY-MM-DD | `--end-date 2023-12-31` | `NULL` |
 

--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -131,6 +131,11 @@ var removeUnprintableCharsFlag = &cli.BoolFlag{
 	Value: false,
 	Usage: "Whether to remove unprintable characters from file names.",
 }
+var requestTimeoutFlag = &cli.IntFlag{
+	Name:  "request-timeout",
+	Value: 30,
+	Usage: "Timeout for each requests in seconds",
+}
 
 var startDateFlag = &cli.StringFlag{
 	Name:  "start-date",
@@ -166,6 +171,7 @@ var app = &cli.App{
 		verboseFlag,
 		skipOnErrorFlag,
 		removeUnprintableCharsFlag,
+		requestTimeoutFlag,
 		startDateFlag,
 		endDateFlag,
 	},
@@ -223,7 +229,12 @@ var app = &cli.App{
 			return retryablehttp.DefaultRetryPolicy(ctx, resp, nil)
 		}
 
-		tlsTransp, err := tlsclient.NewTransportWithOptions(tls_client.NewNoopLogger(), tls_client.WithClientProfile(profiles.Chrome_146_PSK))
+		requestTimeout := c.Int(requestTimeoutFlag.Name)
+		tlsTransp, err := tlsclient.NewTransportWithOptions(
+			tls_client.NewNoopLogger(),
+			tls_client.WithClientProfile(profiles.Chrome_146_PSK),
+			tls_client.WithTimeoutSeconds(requestTimeout),
+		)
 		if err != nil {
 			return fmt.Errorf("create tls transport: %w", err)
 		}

--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -132,6 +132,18 @@ var removeUnprintableCharsFlag = &cli.BoolFlag{
 	Usage: "Whether to remove unprintable characters from file names.",
 }
 
+var startDateFlag = &cli.StringFlag{
+	Name:  "start-date",
+	Usage: "Only download posts published after this date (format: YYYY-MM-DD).",
+	Value: "",
+}
+
+var endDateFlag = &cli.StringFlag{
+	Name:  "end-date",
+	Usage: "Only download posts published before this date (format: YYYY-MM-DD).",
+	Value: "",
+}
+
 var app = &cli.App{
 	Name:  "fanbox-dl",
 	Usage: "This CLI downloads images of supporting and following creators.",
@@ -154,6 +166,8 @@ var app = &cli.App{
 		verboseFlag,
 		skipOnErrorFlag,
 		removeUnprintableCharsFlag,
+		startDateFlag,
+		endDateFlag,
 	},
 	Action: func(c *cli.Context) error {
 		applog.InitLogger(c.Bool(verboseFlag.Name))
@@ -173,6 +187,26 @@ var app = &cli.App{
 			}
 			slog.Debug("Using cookie", "cookie_bytes", len(v))
 			cookieStr = v
+		}
+
+		// Parse date ranges if provided
+		var startDate, endDate *time.Time
+		if startDateStr := c.String(startDateFlag.Name); startDateStr != "" {
+			parsedTime, err := time.Parse("2006-01-02", startDateStr)
+			if err != nil {
+				return fmt.Errorf("invalid start date format (use YYYY-MM-DD): %w", err)
+			}
+			startDate = &parsedTime
+		}
+
+		if endDateStr := c.String(endDateFlag.Name); endDateStr != "" {
+			parsedTime, err := time.Parse("2006-01-02", endDateStr)
+			if err != nil {
+				return fmt.Errorf("invalid end date format (use YYYY-MM-DD): %w", err)
+			}
+			// Set end date to the end of the specified day
+			parsedTime = parsedTime.Add(24*time.Hour - time.Second)
+			endDate = &parsedTime
 		}
 
 		httpClient := retryablehttp.NewClient()
@@ -208,6 +242,8 @@ var app = &cli.App{
 			SkipImages:        c.Bool(skipImages.Name),
 			SkipOnError:       c.Bool(skipOnErrorFlag.Name),
 			OfficialAPIClient: api,
+			StartDate:         startDate,
+			EndDate:           endDate,
 			Storage: &fanbox.LocalStorage{
 				SaveDir:   c.String(saveDirFlag.Name),
 				DirByPost: c.Bool(dirByPostFlag.Name),

--- a/pkg/fanbox/client.go
+++ b/pkg/fanbox/client.go
@@ -71,12 +71,12 @@ func (c *Client) Run(ctx context.Context, creatorID string) error {
 		}
 
 		// Check if we can stop fetching more pages based on dates
-		if c.EndDate != nil && len(content.Body) > 0 {
+		if c.StartDate != nil && len(content.Body) > 0 {
 			// If the last post on this page is older than the start date,
 			// we don't need to check further pages
 			oldestPostTime, err := time.Parse(time.RFC3339, content.Body[len(content.Body)-1].PublishedDateTime)
-			if err == nil && oldestPostTime.Before(*c.EndDate) {
-				slog.InfoContext(ctx, "Reached posts older than end date, stopping pagination")
+			if err == nil && oldestPostTime.Before(*c.StartDate) {
+				slog.InfoContext(ctx, "Reached posts older than start date, stopping pagination")
 				break
 			}
 		}

--- a/pkg/fanbox/client.go
+++ b/pkg/fanbox/client.go
@@ -24,6 +24,8 @@ type Client struct {
 	SkipOnError       bool
 	OfficialAPIClient *OfficialAPIClient
 	Storage           *LocalStorage
+	StartDate         *time.Time
+	EndDate           *time.Time
 }
 
 func (c *Client) Run(ctx context.Context, creatorID string) error {
@@ -43,6 +45,12 @@ func (c *Client) Run(ctx context.Context, creatorID string) error {
 	}
 	slog.DebugContext(ctx, "Found pages", "pages", len(pagination.Pages))
 
+	if c.StartDate != nil || c.EndDate != nil {
+		slog.InfoContext(ctx, "Date filtering active", 
+			"start_date", c.formatDateOrNil(c.StartDate),
+			"end_date", c.formatDateOrNil(c.EndDate))
+	}
+
 	for i, page := range pagination.Pages {
 		content := ListCreatorResponse{}
 		err := c.OfficialAPIClient.RequestAndUnwrapJSON(ctx, http.MethodGet, page, &content)
@@ -61,8 +69,27 @@ func (c *Client) Run(ctx context.Context, creatorID string) error {
 			}
 			return fmt.Errorf("handle page: %w", err)
 		}
+
+		// Check if we can stop fetching more pages based on dates
+		if c.EndDate != nil && len(content.Body) > 0 {
+			// If the last post on this page is older than the start date,
+			// we don't need to check further pages
+			oldestPostTime, err := time.Parse(time.RFC3339, content.Body[len(content.Body)-1].PublishedDateTime)
+			if err == nil && oldestPostTime.Before(*c.EndDate) {
+				slog.InfoContext(ctx, "Reached posts older than end date, stopping pagination")
+				break
+			}
+		}
 	}
 	return nil
+}
+
+// formatDateOrNil returns a formatted date string or "nil" if the date is nil
+func (c *Client) formatDateOrNil(date *time.Time) string {
+	if date == nil {
+		return "nil"
+	}
+	return date.Format("2006-01-02")
 }
 
 func (c *Client) handlePage(ctx context.Context, content *ListCreatorResponse) error {
@@ -80,6 +107,12 @@ func (c *Client) handlePage(ctx context.Context, content *ListCreatorResponse) e
 
 func (c *Client) handlePost(ctx context.Context, item Post) error {
 	ctx = ctxval.AddSlogAttrs(ctx, slog.String("title", item.Title), slog.String("published_at", item.PublishedDateTime))
+
+	// Skip if the post is outside the date range
+	if !c.isWithinDateRange(item.PublishedDateTime) {
+		slog.DebugContext(ctx, "Skipping post outside date range")
+		return nil
+	}
 
 	if item.IsRestricted {
 		slog.DebugContext(ctx, "Skipping restricted post")
@@ -142,6 +175,32 @@ func (c *Client) handlePost(ctx context.Context, item Post) error {
 	}
 
 	return nil
+}
+
+// isWithinDateRange checks if the post's published date is within the specified date range
+func (c *Client) isWithinDateRange(publishedDateTimeStr string) bool {
+	// If no date filters are set, include all posts
+	if c.StartDate == nil && c.EndDate == nil {
+		return true
+	}
+
+	publishedTime, err := time.Parse(time.RFC3339, publishedDateTimeStr)
+	if err != nil {
+		// If we can't parse the date, include the post by default
+		return true
+	}
+
+	// Check if post is after start date (if specified)
+	if c.StartDate != nil && publishedTime.Before(*c.StartDate) {
+		return false
+	}
+
+	// Check if post is before end date (if specified)
+	if c.EndDate != nil && publishedTime.After(*c.EndDate) {
+		return false
+	}
+
+	return true
 }
 
 var errAlreadyDownloaded = errors.New("already downloaded")


### PR DESCRIPTION
## Background

The new tls-client from https://github.com/hareku/fanbox-dl/commit/adfd70fc3f282c934840c364022d23da1ed9fdfe have [30 seconds](https://github.com/bogdanfinn/tls-client/blob/master/client.go#L55) as default timeout which is not enough to download large images or large files.

`time=2025-09-29T01:23:36.978+09:00 level=ERROR msg="fanbox-dl Error" error="failed downloading of \"###\": handle page: handle post: handle file: download: download error: save a file: file copying error: net/http: request canceled (Client.Timeout or context cancellation while reading body)"`

## Changes

- Add flag `--request-timeout`
- Add flags `--start-date` and `--end-date`
  - From #66, other features from the pull requests removed
  - Tested and fixed by human (me)