### PR TITLE
Fix 403 by changing the TLSClient profile

### DIFF
--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -188,7 +188,7 @@ var app = &cli.App{
 			return retryablehttp.DefaultRetryPolicy(ctx, resp, nil)
 		}
 
-		tlsTransp, err := tlsclient.NewTransportWithOptions(tls_client.NewNoopLogger(), tls_client.WithClientProfile(profiles.Chrome_133))
+		tlsTransp, err := tlsclient.NewTransportWithOptions(tls_client.NewNoopLogger(), tls_client.WithClientProfile(profiles.Chrome_131))
 		if err != nil {
 			return fmt.Errorf("create tls transport: %w", err)
 		}


### PR DESCRIPTION
Suggestion, make a CLI argument to change the profile to avoid this from happening in future (that also means they'll have to look for another way to block us, and they might come up with a new way)
This PR will solve #79 and potentially #78, #74 