### PR TITLE
Add rate limiter for API calls

### DIFF
--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -131,6 +131,11 @@ var removeUnprintableCharsFlag = &cli.BoolFlag{
 	Value: false,
 	Usage: "Whether to remove unprintable characters from file names.",
 }
+var maxRequestsPerMinuteFlag = &cli.IntFlag{
+	Name:  "max-rpm",
+	Value: 40,
+	Usage: "Maximum number of requests per minute to Fanbox API.",
+}
 
 var app = &cli.App{
 	Name:  "fanbox-dl",
@@ -154,6 +159,7 @@ var app = &cli.App{
 		verboseFlag,
 		skipOnErrorFlag,
 		removeUnprintableCharsFlag,
+		maxRequestsPerMinuteFlag,
 	},
 	Action: func(c *cli.Context) error {
 		applog.InitLogger(c.Bool(verboseFlag.Name))
@@ -194,11 +200,7 @@ var app = &cli.App{
 		}
 		httpClient.HTTPClient.Transport = tlsTransp
 
-		api := &fanbox.OfficialAPIClient{
-			HTTPClient: httpClient,
-			Cookie:     cookieStr,
-			UserAgent:  c.String(userAgentFlag.Name),
-		}
+		api := fanbox.NewOfficialAPIClient(httpClient, cookieStr, c.String(userAgentFlag.Name), c.Int(maxRequestsPerMinuteFlag.Name))
 
 		client := &fanbox.Client{
 			CheckAllPosts:     c.Bool(allFlag.Name),

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 require (
 	github.com/Dharmey747/quic-go-utls v1.0.3-utls // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/bogdanfinn/utls v1.7.3-barnius // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
@@ -29,6 +30,7 @@ require (
 	github.com/tam7t/hpkp v0.0.0-20160821193359-2b70b4024ed5 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	go.uber.org/mock v0.5.0 // indirect
+	go.uber.org/ratelimit v0.3.1 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Dharmey747/quic-go-utls v1.0.3-utls h1:wqvk69LgFwT6AtTW14ASpRIJkvCaH2
 github.com/Dharmey747/quic-go-utls v1.0.3-utls/go.mod h1:lgQoyZzST8vJJQ84eF9Xi2xJJnujoiNk0FGFEyQonG8=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bogdanfinn/fhttp v0.6.0 h1:24JoDnE43tq3RdK99K1M5mxa2JyntKr6WcDsy1KdA0o=
 github.com/bogdanfinn/fhttp v0.6.0/go.mod h1:ZR1hRfxsOd/j/C8RnwyNXA90DxkrHB3Y1nuCD1YlbdI=
 github.com/bogdanfinn/tls-client v1.11.0 h1:JCSSf2CSEHPB6Rk8amTeaW84iXdapDbjVl6O4/s1sn8=
@@ -50,6 +52,8 @@ github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZ
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
 go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
+go.uber.org/ratelimit v0.3.1 h1:K4qVE+byfv/B3tC+4nYWP7v/6SimcO7HzHekoMNBma0=
+go.uber.org/ratelimit v0.3.1/go.mod h1:6euWsTB6U/Nb3X++xEUXA8ciPJvr19Q/0h1+oDcJhRk=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=

--- a/pkg/fanbox/client_test.go
+++ b/pkg/fanbox/client_test.go
@@ -133,13 +133,11 @@ func TestClient_Run(t *testing.T) {
 			})
 
 			client := fanbox.Client{
-				CheckAllPosts: true,
-				DryRun:        tt.config.dryRun,
-				SkipFiles:     tt.config.skipFiles,
-				SkipImages:    tt.config.skipImages,
-				OfficialAPIClient: &fanbox.OfficialAPIClient{
-					HTTPClient: httpClient,
-				},
+				CheckAllPosts:     true,
+				DryRun:            tt.config.dryRun,
+				SkipFiles:         tt.config.skipFiles,
+				SkipImages:        tt.config.skipImages,
+				OfficialAPIClient: fanbox.NewOfficialAPIClient(httpClient, "", "", 1000),
 				Storage: &fanbox.LocalStorage{
 					SaveDir:   saveDir,
 					DirByPost: tt.config.dirByPost,

--- a/pkg/fanbox/official_api_client.go
+++ b/pkg/fanbox/official_api_client.go
@@ -11,17 +11,32 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"reflect"
+	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"go.uber.org/ratelimit"
 )
 
 type OfficialAPIClient struct {
 	HTTPClient *retryablehttp.Client
 	Cookie     string
 	UserAgent  string
+
+	limiter ratelimit.Limiter
+}
+
+func NewOfficialAPIClient(httpClient *retryablehttp.Client, cookie string, userAgent string, maxRequestsPerMinute int) *OfficialAPIClient {
+	return &OfficialAPIClient{
+		HTTPClient: httpClient,
+		Cookie:     cookie,
+		UserAgent:  userAgent,
+		limiter:    ratelimit.New(maxRequestsPerMinute, ratelimit.Per(time.Minute)),
+	}
 }
 
 func (c *OfficialAPIClient) Request(ctx context.Context, method string, url string) (*http.Response, error) {
+	c.limiter.Take()
+
 	req, err := retryablehttp.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("http request building error: %w", err)


### PR DESCRIPTION
This will limit the number of API calls to Pixiv to 40 requests per minute by default, customizable through a CLI flag