### PR TITLE
Add rate limiting feature to prevent API throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The latest binary can be downloaded [here](https://github.com/hareku/fanbox-dl/r
 | save-dir | Root directory to save content. <br>Put directory in double quotes `"` if it contains spaces. <br> Supports relative and absolute directories. | `--save-dir ./content` | `./images` |
 | user-agent | User agent to use for requests. | `--user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"` | `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3` |
 | remove-unprintable-chars | Removes unprintable characters from the file name. In some environments, unprintable characters are not allowed in file names. | `--remove-unprintable-chars` | `false` |
+| rate-limit | Maximum number of requests per second (0 = unlimited). <br>Useful to avoid rate limiting when downloading large amounts of content. <br>Example: `--rate-limit 2` limits to 2 requests per second. | `--rate-limit 2` | `0` (unlimited) |
 
 ### Example
 

--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hareku/fanbox-dl/pkg/fanbox"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/time/rate"
 )
 
 func resolveSessionID(c *cli.Context) string {
@@ -131,6 +132,11 @@ var removeUnprintableCharsFlag = &cli.BoolFlag{
 	Value: false,
 	Usage: "Whether to remove unprintable characters from file names.",
 }
+var rateLimitFlag = &cli.Float64Flag{
+	Name:  "rate-limit",
+	Value: 0,
+	Usage: "Maximum number of requests per second (0 = unlimited). Example: --rate-limit 2 limits to 2 requests/second.",
+}
 
 var app = &cli.App{
 	Name:  "fanbox-dl",
@@ -154,6 +160,7 @@ var app = &cli.App{
 		verboseFlag,
 		skipOnErrorFlag,
 		removeUnprintableCharsFlag,
+		rateLimitFlag,
 	},
 	Action: func(c *cli.Context) error {
 		applog.InitLogger(c.Bool(verboseFlag.Name))
@@ -194,10 +201,18 @@ var app = &cli.App{
 		}
 		httpClient.HTTPClient.Transport = tlsTransp
 
+		// Setup rate limiter if specified
+		var rateLimiter *rate.Limiter
+		if rateLimit := c.Float64(rateLimitFlag.Name); rateLimit > 0 {
+			slog.Info("Rate limiting enabled", "requests_per_second", rateLimit)
+			rateLimiter = rate.NewLimiter(rate.Limit(rateLimit), 1)
+		}
+
 		api := &fanbox.OfficialAPIClient{
-			HTTPClient: httpClient,
-			Cookie:     cookieStr,
-			UserAgent:  c.String(userAgentFlag.Name),
+			HTTPClient:  httpClient,
+			Cookie:      cookieStr,
+			UserAgent:   c.String(userAgentFlag.Name),
+			RateLimiter: rateLimiter,
 		}
 
 		client := &fanbox.Client{

--- a/pkg/fanbox/official_api_client.go
+++ b/pkg/fanbox/official_api_client.go
@@ -13,15 +13,24 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"golang.org/x/time/rate"
 )
 
 type OfficialAPIClient struct {
-	HTTPClient *retryablehttp.Client
-	Cookie     string
-	UserAgent  string
+	HTTPClient  *retryablehttp.Client
+	Cookie      string
+	UserAgent   string
+	RateLimiter *rate.Limiter
 }
 
 func (c *OfficialAPIClient) Request(ctx context.Context, method string, url string) (*http.Response, error) {
+	// Apply rate limiting if configured
+	if c.RateLimiter != nil {
+		if err := c.RateLimiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("rate limiter wait error: %w", err)
+		}
+	}
+
 	req, err := retryablehttp.NewRequest(method, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("http request building error: %w", err)


### PR DESCRIPTION
Implements a configurable rate limiter to control request frequency when downloading from Pixiv FANBOX, helping avoid rate limiting issues when processing large amounts of content.

Changes:
- Add --rate-limit flag to specify max requests per second
- Integrate golang.org/x/time/rate token bucket rate limiter
- Apply rate limiting to all HTTP requests in OfficialAPIClient
- Update README with rate-limit flag documentation

Usage example:
  fanbox-dl --rate-limit 2 --creator username

This limits the application to 2 requests per second, preventing FANBOX from rate limiting the connection during bulk downloads.