### PR TITLE
Fix follower list retrieving

### DIFF
--- a/pkg/fanbox/creator_id_lister.go
+++ b/pkg/fanbox/creator_id_lister.go
@@ -58,12 +58,12 @@ func (c *CreatorIDLister) all(ctx context.Context, in *CreatorIDListerDoInput) (
 	}
 
 	if in.IncludeFollowing {
-		following := PlanListSupportingResponse{}
+		following := PlanListFollowingResponse{}
 		err := c.OfficialAPIClient.RequestAndUnwrapJSON(ctx, http.MethodGet, "https://api.fanbox.cc/creator.listFollowing", &following)
 		if err != nil {
 			return nil, fmt.Errorf("list following creators: %w", err)
 		}
-		for _, f := range following.Body {
+		for _, f := range following.Body.Creators {
 			ids[f.CreatorID] = nil
 		}
 	}

--- a/pkg/fanbox/official_api_response.go
+++ b/pkg/fanbox/official_api_response.go
@@ -138,6 +138,14 @@ type PlanListSupportingResponse struct {
 	Body []Plan `json:"body"`
 }
 
+type PlanListFollowingResponse struct {
+	Body PlanListCreators `json:"body"`
+}
+
+type PlanListCreators struct {
+	Creators []Plan `json:"creators"`
+}
+
 type Plan struct {
 	CreatorID string `json:"creatorId"`
 }


### PR DESCRIPTION
Closes #88 
The supporting list is like:
`{"body":[{"creatorId":"`
But, follow list is now:
`{"body":{"creators":[{"user":{"userId"`
So, I added `PlanListFollowingResponse` and `PlanListCreators` to properly parse the new schema.