### PR TITLE
feat: add Nix flake for building and installing on NixOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ images/
 dist/
 
 .envrc
+
+# Nix build output
+result
+result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "Pixiv FANBOX downloader";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      rev = self.shortRev or self.dirtyShortRev or "dev";
+    in
+    {
+      packages = forAllSystems (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        {
+          default = pkgs.buildGoModule {
+            pname = "fanbox-dl";
+            version = rev;
+
+            src = ./.;
+            vendorHash = "sha256-o9/e8IbWN7PzOG60B2IBwVYIWM1qTeYC4EdubdG179s=";
+
+            subPackages = [ "cmd/fanbox-dl" ];
+
+            env.CGO_ENABLED = 0;
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X=main.version=${rev}"
+              "-X=main.commit=${self.rev or self.dirtyRev or "none"}"
+            ];
+
+            meta = with pkgs.lib; {
+              description = "Pixiv FANBOX downloader";
+              homepage = "https://github.com/hareku/fanbox-dl";
+              license = licenses.mit;
+              mainProgram = "fanbox-dl";
+            };
+          };
+        });
+    };
+}


### PR DESCRIPTION
Provides a flake.nix using buildGoModule so the tool can be built, run, and installed via the standard Nix CLI on any supported system (x86_64/aarch64 Linux and macOS).

### Usage:
```
  nix build                 # produces ./result/bin/fanbox-dl
  nix run . -- --help       # run without installing
  nix profile install .     # install to the user profile
```

### Details:
- Pins nixpkgs-unstable (currently ships Go 1.26.3, matching go.mod).
- Builds only ./cmd/fanbox-dl via subPackages to skip test-only code.
- Sets CGO_ENABLED=0 to match .goreleaser.yaml.
- Strips the binary with -ldflags=-s -w and injects main.version / main.commit from the git revision (falls back to dirtyShortRev / dirtyRev when the worktree is uncommitted, "dev" / "none" otherwise).
- vendorHash is pinned; bumping deps requires replacing it with lib.fakeHash, re-running nix build, and pasting back the hash Nix reports.
- Adds result/result-* to .gitignore so the Nix build symlink is not tracked.

I've tested this feature on my system and I'm able to run the tool after installing it. Let me know if you have any questions.