### PR TITLE
Fix: resolve Cloudflare 403 errors

### DIFF
--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -69,7 +69,7 @@ var cookieFlag = &cli.StringFlag{
 var userAgentFlag = &cli.StringFlag{
 	Name:  "user-agent",
 	Usage: "User-Agent for Fanbox API.",
-	Value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+	Value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
 }
 var saveDirFlag = &cli.StringFlag{
 	Name:  "save-dir",
@@ -188,7 +188,7 @@ var app = &cli.App{
 			return retryablehttp.DefaultRetryPolicy(ctx, resp, nil)
 		}
 
-		tlsTransp, err := tlsclient.NewTransportWithOptions(tls_client.NewNoopLogger(), tls_client.WithClientProfile(profiles.Chrome_131))
+		tlsTransp, err := tlsclient.NewTransportWithOptions(tls_client.NewNoopLogger(), tls_client.WithClientProfile(profiles.Chrome_146_PSK))
 		if err != nil {
 			return fmt.Errorf("create tls transport: %w", err)
 		}

--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -176,6 +176,7 @@ var app = &cli.App{
 		}
 
 		httpClient := retryablehttp.NewClient()
+		httpClient.HTTPClient.Jar = fanbox.NewCookieJar()
 		httpClient.Logger = applog.NewRetryableLeveledLogger(slog.Default())
 		httpClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 			if err != nil {

--- a/pkg/fanbox/client_test.go
+++ b/pkg/fanbox/client_test.go
@@ -126,6 +126,7 @@ func TestClient_Run(t *testing.T) {
 	}
 
 	httpClient := retryablehttp.NewClient()
+	httpClient.HTTPClient.Jar = fanbox.NewCookieJar()
 	tlsTransp, err := tlsclient.NewTransportWithOptions(tls_client.NewNoopLogger(), tls_client.WithClientProfile(profiles.Chrome_146_PSK))
 	require.NoError(t, err)
 	httpClient.HTTPClient.Transport = tlsTransp

--- a/pkg/fanbox/client_test.go
+++ b/pkg/fanbox/client_test.go
@@ -126,7 +126,7 @@ func TestClient_Run(t *testing.T) {
 	}
 
 	httpClient := retryablehttp.NewClient()
-	tlsTransp, err := tlsclient.NewTransportWithOptions(tls_client.NewNoopLogger(), tls_client.WithClientProfile(profiles.Chrome_131))
+	tlsTransp, err := tlsclient.NewTransportWithOptions(tls_client.NewNoopLogger(), tls_client.WithClientProfile(profiles.Chrome_146_PSK))
 	require.NoError(t, err)
 	httpClient.HTTPClient.Transport = tlsTransp
 
@@ -145,7 +145,7 @@ func TestClient_Run(t *testing.T) {
 				SkipImages:    tt.config.skipImages,
 				OfficialAPIClient: &fanbox.OfficialAPIClient{
 					HTTPClient: httpClient,
-					UserAgent:  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+					UserAgent:  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
 				},
 				Storage: &fanbox.LocalStorage{
 					SaveDir:   saveDir,

--- a/pkg/fanbox/cookie_jar.go
+++ b/pkg/fanbox/cookie_jar.go
@@ -1,0 +1,11 @@
+package fanbox
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+)
+
+func NewCookieJar() http.CookieJar {
+	jar, _ := cookiejar.New(nil)
+	return jar
+}

--- a/pkg/fanbox/official_api_client.go
+++ b/pkg/fanbox/official_api_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -67,6 +68,19 @@ func (c *OfficialAPIClient) RequestAndUnwrapJSON(ctx context.Context, method str
 }
 
 var ErrFailedToThumbnailing = fmt.Errorf("failed to thumbnailing")
+
+var ErrInvalidSession = errors.New("invalid session")
+
+func (c *OfficialAPIClient) ValidateSession(ctx context.Context) error {
+	var resp PlanListSupportingResponse
+	if err := c.RequestAndUnwrapJSON(ctx, http.MethodGet, "https://api.fanbox.cc/plan.listSupporting", &resp); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidSession, err)
+	}
+	if len(resp.Body) == 0 {
+		return ErrInvalidSession
+	}
+	return nil
+}
 
 // fanbox returns HTTP 500 error and response body is "failed to thumbnailing"
 // when the image is not available (e.g. too large).

--- a/pkg/fanbox/official_api_client_test.go
+++ b/pkg/fanbox/official_api_client_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+package fanbox_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	tls_client "github.com/bogdanfinn/tls-client"
+	"github.com/bogdanfinn/tls-client/profiles"
+	"github.com/hareku/fanbox-dl/internal/tlsclient"
+	"github.com/hareku/fanbox-dl/pkg/fanbox"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSession_Valid(t *testing.T) {
+	sessID := os.Getenv("FANBOXSESSID")
+	if sessID == "" {
+		t.Skip("FANBOXSESSID env var is not set")
+	}
+
+	c := newClient(t, fmt.Sprintf("FANBOXSESSID=%s", sessID))
+	require.NoError(t, c.ValidateSession(context.Background()))
+}
+
+func TestValidateSession_Missing(t *testing.T) {
+	c := newClient(t, "")
+	err := c.ValidateSession(context.Background())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, fanbox.ErrInvalidSession))
+}
+
+func TestValidateSession_Invalid(t *testing.T) {
+	t.Setenv("FANBOXSESSID", "definitely_invalid_value")
+
+	sessID := os.Getenv("FANBOXSESSID")
+	require.NotEmpty(t, sessID)
+
+	c := newClient(t, fmt.Sprintf("FANBOXSESSID=%s", sessID))
+	err := c.ValidateSession(context.Background())
+	require.Error(t, err)
+}
+
+func newClient(t *testing.T, cookie string) *fanbox.OfficialAPIClient {
+	t.Helper()
+
+	httpClient := retryablehttp.NewClient()
+	httpClient.HTTPClient.Jar = fanbox.NewCookieJar()
+	tlsTransp, err := tlsclient.NewTransportWithOptions(tls_client.NewNoopLogger(), tls_client.WithClientProfile(profiles.Chrome_146_PSK))
+	require.NoError(t, err)
+	httpClient.HTTPClient.Transport = tlsTransp
+
+	return &fanbox.OfficialAPIClient{
+		HTTPClient: httpClient,
+		Cookie:     cookie,
+		UserAgent:  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+	}
+}


### PR DESCRIPTION
This fixes the issue in #96 caused by Cloudflare's `__cf_bm` cookies included in the response.

## Problem

The `post.info` endpoint was returning HTTP 403 Cloudflare challenge
pages, breaking both `fanbox-dl` and the integration test suite. Two
issues were identified:

1. **Stale TLS fingerprint** -- The JA3 profile was Chrome 131, while
   the User-Agent header advertised Chrome 133. Cloudflare probably flags this
   mismatch as a bot signal.

2. **Missing cookie propagation** -- `post.paginateCreator` and
   `post.listCreator` responses include `__cf_bm` (Cloudflare bot
   management) cookies, but no cookie jar was configured. Without
   carrying these cookies forward, `post.info` appeared as a cold
   untrusted visitor and triggered the challenge page.

## Changes

- **Bump TLS profile** from `Chrome_131` to `Chrome_146_PSK` and
  align User-Agent to Chrome 146 in `main.go` and `client_test.go`

- **Add cookie jar** (`pkg/fanbox/cookie_jar.go`) and configure it on
  all `retryablehttp.Client` instances so `__cf_bm` cookies propagate
  across API requests

- **Add `ValidateSession`** method on `OfficialAPIClient` that calls
  `plan.listSupporting` to check whether a `FANBOXSESSID` cookie is
  valid, with a sentinel `ErrInvalidSession` error

- **Add integration tests** for `ValidateSession` with three subtests:
  valid cookie (reads `FANBOXSESSID` from env, skips if unset),
  missing cookie, and invalid cookie

## Testing

You can try to validate your session ID against the Fanbox endpoint either using only the session validation test
```bash
go clean -testcache && FANBOXSESSID=your_session_id \
  go test -count=1 -tags=integration \
  -run TestValidateSession_Valid -v ./pkg/fanbox/ 2>&1
```
or full suite test.
```bash
go clean -testcache && FANBOXSESSID=your_session_id make test-integration
```