### PR TITLE
fix: replace total request timeout with idle timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The latest binary can be downloaded [here](https://github.com/hareku/fanbox-dl/r
 | save-dir | Root directory to save content. <br>Put directory in double quotes `"` if it contains spaces. <br> Supports relative and absolute directories. | `--save-dir ./content` | `./images` |
 | user-agent | User agent to use for requests. | `--user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"` | `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3` |
 | remove-unprintable-chars | Removes unprintable characters from the file name. In some environments, unprintable characters are not allowed in file names. | `--remove-unprintable-chars` | `false` |
+| request-idle-timeout | Maximum seconds without receiving response data. Zero disables the timeout. | `--request-idle-timeout 60` | `30` |
 
 ### Example
 

--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -131,6 +131,11 @@ var removeUnprintableCharsFlag = &cli.BoolFlag{
 	Value: false,
 	Usage: "Whether to remove unprintable characters from file names.",
 }
+var requestIdleTimeoutFlag = &cli.UintFlag{
+	Name:  "request-idle-timeout",
+	Value: 30,
+	Usage: "Maximum seconds without receiving response data. Zero disables the timeout.",
+}
 
 var app = &cli.App{
 	Name:  "fanbox-dl",
@@ -154,6 +159,7 @@ var app = &cli.App{
 		verboseFlag,
 		skipOnErrorFlag,
 		removeUnprintableCharsFlag,
+		requestIdleTimeoutFlag,
 	},
 	Action: func(c *cli.Context) error {
 		applog.InitLogger(c.Bool(verboseFlag.Name))
@@ -189,7 +195,11 @@ var app = &cli.App{
 			return retryablehttp.DefaultRetryPolicy(ctx, resp, nil)
 		}
 
-		tlsTransp, err := tlsclient.NewTransportWithOptions(tls_client.NewNoopLogger(), tls_client.WithClientProfile(profiles.Chrome_146_PSK))
+		tlsTransp, err := tlsclient.NewTransportWithIdleTimeout(
+			tls_client.NewNoopLogger(),
+			time.Duration(c.Uint(requestIdleTimeoutFlag.Name))*time.Second,
+			tls_client.WithClientProfile(profiles.Chrome_146_PSK),
+		)
 		if err != nil {
 			return fmt.Errorf("create tls transport: %w", err)
 		}

--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -180,6 +180,10 @@ var app = &cli.App{
 			slog.Debug("Using cookie", "cookie_bytes", len(v))
 			cookieStr = v
 		}
+		requestIdleTimeout, err := parseRequestIdleTimeout(uint64(c.Uint(requestIdleTimeoutFlag.Name)))
+		if err != nil {
+			return err
+		}
 
 		httpClient := retryablehttp.NewClient()
 		httpClient.HTTPClient.Jar = fanbox.NewCookieJar()
@@ -188,7 +192,7 @@ var app = &cli.App{
 
 		tlsTransp, err := tlsclient.NewTransportWithIdleTimeout(
 			tls_client.NewNoopLogger(),
-			time.Duration(c.Uint(requestIdleTimeoutFlag.Name))*time.Second,
+			requestIdleTimeout,
 			tls_client.WithClientProfile(profiles.Chrome_146_PSK),
 		)
 		if err != nil {
@@ -250,6 +254,15 @@ var app = &cli.App{
 		slog.InfoContext(ctx, "Completed.", "duration", time.Since(startedAt).Round(time.Millisecond*100))
 		return nil
 	},
+}
+
+const maxRequestIdleTimeoutSeconds uint64 = (1<<63 - 1) / uint64(time.Second)
+
+func parseRequestIdleTimeout(seconds uint64) (time.Duration, error) {
+	if seconds > maxRequestIdleTimeoutSeconds {
+		return 0, fmt.Errorf("--%s must not exceed %d seconds", requestIdleTimeoutFlag.Name, maxRequestIdleTimeoutSeconds)
+	}
+	return time.Duration(seconds) * time.Second, nil
 }
 
 func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {

--- a/cmd/fanbox-dl/main.go
+++ b/cmd/fanbox-dl/main.go
@@ -133,7 +133,7 @@ var removeUnprintableCharsFlag = &cli.BoolFlag{
 }
 var requestIdleTimeoutFlag = &cli.UintFlag{
 	Name:  "request-idle-timeout",
-	Value: 30,
+	Value: uint(tlsclient.DefaultRequestIdleTimeout / time.Second),
 	Usage: "Maximum seconds without receiving response data. Zero disables the timeout.",
 }
 
@@ -184,16 +184,7 @@ var app = &cli.App{
 		httpClient := retryablehttp.NewClient()
 		httpClient.HTTPClient.Jar = fanbox.NewCookieJar()
 		httpClient.Logger = applog.NewRetryableLeveledLogger(slog.Default())
-		httpClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-			if err != nil {
-				return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
-			}
-			b, err := fanbox.IsFailedToThumbnailingErr(resp)
-			if err == nil && b {
-				return false, fanbox.ErrFailedToThumbnailing
-			}
-			return retryablehttp.DefaultRetryPolicy(ctx, resp, nil)
-		}
+		httpClient.CheckRetry = checkRetry
 
 		tlsTransp, err := tlsclient.NewTransportWithIdleTimeout(
 			tls_client.NewNoopLogger(),
@@ -259,6 +250,24 @@ var app = &cli.App{
 		slog.InfoContext(ctx, "Completed.", "duration", time.Since(startedAt).Round(time.Millisecond*100))
 		return nil
 	},
+}
+
+func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if errors.Is(err, tlsclient.ErrRequestIdleTimeout) {
+		return false, nil
+	}
+	if err != nil {
+		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+	}
+
+	b, err := fanbox.IsFailedToThumbnailingErr(resp)
+	if err == nil && b {
+		return false, fanbox.ErrFailedToThumbnailing
+	}
+	return retryablehttp.DefaultRetryPolicy(ctx, resp, nil)
 }
 
 func main() {

--- a/cmd/fanbox-dl/main_test.go
+++ b/cmd/fanbox-dl/main_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hareku/fanbox-dl/internal/tlsclient"
 	"github.com/stretchr/testify/require"
@@ -19,6 +20,25 @@ func TestCheckRetryDoesNotRetryRequestIdleTimeout(t *testing.T) {
 
 	require.NoError(t, err)
 	require.False(t, retry)
+}
+
+func TestRequestIdleTimeout(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		got, err := parseRequestIdleTimeout(30)
+		require.NoError(t, err)
+		require.Equal(t, 30*time.Second, got)
+	})
+
+	t.Run("maximum", func(t *testing.T) {
+		got, err := parseRequestIdleTimeout(maxRequestIdleTimeoutSeconds)
+		require.NoError(t, err)
+		require.Equal(t, time.Duration(maxRequestIdleTimeoutSeconds)*time.Second, got)
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		_, err := parseRequestIdleTimeout(maxRequestIdleTimeoutSeconds + 1)
+		require.EqualError(t, err, "--request-idle-timeout must not exceed 9223372036 seconds")
+	})
 }
 
 func TestCheckRetryRetainsDefaultHandlingForOtherErrors(t *testing.T) {

--- a/cmd/fanbox-dl/main_test.go
+++ b/cmd/fanbox-dl/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hareku/fanbox-dl/internal/tlsclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckRetryDoesNotRetryRequestIdleTimeout(t *testing.T) {
+	retry, err := checkRetry(
+		context.Background(),
+		nil,
+		fmt.Errorf("request failed: %w", tlsclient.ErrRequestIdleTimeout),
+	)
+
+	require.NoError(t, err)
+	require.False(t, retry)
+}
+
+func TestCheckRetryRetainsDefaultHandlingForOtherErrors(t *testing.T) {
+	retry, err := checkRetry(context.Background(), nil, errors.New("connection failed"))
+
+	require.NoError(t, err)
+	require.True(t, retry)
+}
+
+func TestCheckRetryPreservesRequestCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	retry, err := checkRetry(ctx, nil, tlsclient.ErrRequestIdleTimeout)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, retry)
+}

--- a/internal/tlsclient/idle_timeout_body.go
+++ b/internal/tlsclient/idle_timeout_body.go
@@ -5,50 +5,95 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"sync/atomic"
+	"sync"
 	"time"
 )
 
+// ErrRequestIdleTimeout indicates that a request stopped receiving response data.
 var ErrRequestIdleTimeout = errors.New("request idle timeout")
 
 type idleTimeoutBody struct {
 	io.ReadCloser
 	timeout time.Duration
 	cancel  context.CancelFunc
+
+	mu        sync.Mutex
+	timer     *time.Timer
+	timedOut  bool
+	closed    bool
+	closeErr  error
+	closeOnce sync.Once
 }
 
 func newIdleTimeoutBody(body io.ReadCloser, timeout time.Duration, cancel context.CancelFunc) io.ReadCloser {
-	return &idleTimeoutBody{
+	b := &idleTimeoutBody{
 		ReadCloser: body,
 		timeout:    timeout,
 		cancel:     cancel,
 	}
+	b.timer = time.AfterFunc(timeout, b.triggerTimeout)
+	return b
 }
 
 func (b *idleTimeoutBody) Read(p []byte) (int, error) {
-	var timedOut atomic.Bool
-	timerDone := make(chan struct{})
-	timer := time.AfterFunc(b.timeout, func() {
-		timedOut.Store(true)
-		b.cancel()
-		_ = b.ReadCloser.Close()
-		close(timerDone)
-	})
-
 	n, err := b.ReadCloser.Read(p)
-	if !timer.Stop() {
-		<-timerDone
-	}
-	if timedOut.Load() {
+
+	b.mu.Lock()
+	if b.timedOut {
+		b.mu.Unlock()
 		return n, newRequestIdleTimeoutError(b.timeout)
 	}
+	if b.closed {
+		b.mu.Unlock()
+		return n, err
+	}
+	if err != nil {
+		b.timer.Stop()
+		b.mu.Unlock()
+		return n, err
+	}
+	if n == 0 {
+		b.mu.Unlock()
+		return n, nil
+	}
+	if !b.timer.Stop() {
+		b.mu.Unlock()
+		b.triggerTimeout()
+		return n, newRequestIdleTimeoutError(b.timeout)
+	}
+	b.timer.Reset(b.timeout)
+	b.mu.Unlock()
 
-	return n, err
+	return n, nil
 }
 
 func (b *idleTimeoutBody) Close() error {
-	b.cancel()
-	return b.ReadCloser.Close()
+	b.mu.Lock()
+	b.closed = true
+	b.timer.Stop()
+	b.mu.Unlock()
+
+	return b.closeUnderlying()
+}
+
+func (b *idleTimeoutBody) triggerTimeout() {
+	b.mu.Lock()
+	if b.closed || b.timedOut {
+		b.mu.Unlock()
+		return
+	}
+	b.timedOut = true
+	b.mu.Unlock()
+
+	_ = b.closeUnderlying()
+}
+
+func (b *idleTimeoutBody) closeUnderlying() error {
+	b.closeOnce.Do(func() {
+		b.cancel()
+		b.closeErr = b.ReadCloser.Close()
+	})
+	return b.closeErr
 }
 
 func newRequestIdleTimeoutError(timeout time.Duration) error {

--- a/internal/tlsclient/idle_timeout_body.go
+++ b/internal/tlsclient/idle_timeout_body.go
@@ -1,0 +1,56 @@
+package tlsclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+)
+
+var ErrRequestIdleTimeout = errors.New("request idle timeout")
+
+type idleTimeoutBody struct {
+	io.ReadCloser
+	timeout time.Duration
+	cancel  context.CancelFunc
+}
+
+func newIdleTimeoutBody(body io.ReadCloser, timeout time.Duration, cancel context.CancelFunc) io.ReadCloser {
+	return &idleTimeoutBody{
+		ReadCloser: body,
+		timeout:    timeout,
+		cancel:     cancel,
+	}
+}
+
+func (b *idleTimeoutBody) Read(p []byte) (int, error) {
+	var timedOut atomic.Bool
+	timerDone := make(chan struct{})
+	timer := time.AfterFunc(b.timeout, func() {
+		timedOut.Store(true)
+		b.cancel()
+		_ = b.ReadCloser.Close()
+		close(timerDone)
+	})
+
+	n, err := b.ReadCloser.Read(p)
+	if !timer.Stop() {
+		<-timerDone
+	}
+	if timedOut.Load() {
+		return n, newRequestIdleTimeoutError(b.timeout)
+	}
+
+	return n, err
+}
+
+func (b *idleTimeoutBody) Close() error {
+	b.cancel()
+	return b.ReadCloser.Close()
+}
+
+func newRequestIdleTimeoutError(timeout time.Duration) error {
+	return fmt.Errorf("%w after %s", ErrRequestIdleTimeout, timeout)
+}

--- a/internal/tlsclient/transport.go
+++ b/internal/tlsclient/transport.go
@@ -2,6 +2,7 @@ package tlsclient
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -162,7 +163,7 @@ func convertToFhttpRequest(req *http.Request) (*fhttp.Request, error) {
 // convertFromFhttpResponse converts fhttp.Response to net/http.Response
 func convertFromFhttpResponse(fResp *fhttp.Response, originalReq *http.Request) (*http.Response, error) {
 	if fResp == nil {
-		return nil, nil
+		return nil, errors.New("fhttp response is nil")
 	}
 
 	// Create new net/http.Response

--- a/internal/tlsclient/transport.go
+++ b/internal/tlsclient/transport.go
@@ -1,7 +1,10 @@
 package tlsclient
 
 import (
+	"context"
 	"net/http"
+	"sync/atomic"
+	"time"
 
 	fhttp "github.com/bogdanfinn/fhttp"
 	tls_client "github.com/bogdanfinn/tls-client"
@@ -9,49 +12,106 @@ import (
 
 // Transport implements net/http.RoundTripper using tls-client.HttpClient
 type Transport struct {
-	client tls_client.HttpClient
+	client             tls_client.HttpClient
+	requestIdleTimeout time.Duration
 }
 
 // Ensure Transport implements http.RoundTripper
 var _ http.RoundTripper = (*Transport)(nil)
 
+const DefaultRequestIdleTimeout = 30 * time.Second
+
 // NewTransportWithOptions creates a new Transport with the given options
 func NewTransportWithOptions(logger tls_client.Logger, options ...tls_client.HttpClientOption) (*Transport, error) {
-	// Ensure no redirect following for RoundTripper compatibility
-	options = append(options, tls_client.WithNotFollowRedirects())
+	return NewTransportWithIdleTimeout(logger, DefaultRequestIdleTimeout, options...)
+}
 
-	client, err := tls_client.NewHttpClient(logger, options...)
+// NewTransportWithIdleTimeout creates a new Transport with the given request
+// idle timeout and tls-client options. A zero timeout disables idle checks.
+func NewTransportWithIdleTimeout(logger tls_client.Logger, idleTimeout time.Duration, options ...tls_client.HttpClientOption) (*Transport, error) {
+	// A net/http.Transport does not impose a deadline on the entire request.
+	// Match that behavior so large response bodies are not cut off by
+	// tls-client's default 30-second timeout. Callers can still provide an
+	// explicit timeout option, and request contexts continue to cancel requests.
+	clientOptions := []tls_client.HttpClientOption{tls_client.WithTimeoutSeconds(0)}
+	clientOptions = append(clientOptions, options...)
+
+	// Ensure no redirect following for RoundTripper compatibility.
+	clientOptions = append(clientOptions, tls_client.WithNotFollowRedirects())
+
+	client, err := tls_client.NewHttpClient(logger, clientOptions...)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Transport{
-		client: client,
+		client:             client,
+		requestIdleTimeout: idleTimeout,
 	}, nil
 }
 
 // RoundTrip executes a single HTTP transaction
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	request := req
+	cancel := context.CancelFunc(func() {})
+	var timedOut atomic.Bool
+	var timer *time.Timer
+	var timerDone chan struct{}
+	stopTimer := func() {
+		if timer != nil && !timer.Stop() {
+			<-timerDone
+		}
+	}
+	if t.requestIdleTimeout > 0 {
+		ctx, cancelRequest := context.WithCancel(req.Context())
+		cancel = cancelRequest
+		request = req.WithContext(ctx)
+
+		timerDone = make(chan struct{})
+		timer = time.AfterFunc(t.requestIdleTimeout, func() {
+			timedOut.Store(true)
+			cancelRequest()
+			close(timerDone)
+		})
+	}
+
 	// Convert net/http.Request to fhttp.Request
-	fReq, err := convertToFhttpRequest(req)
+	fReq, err := convertToFhttpRequest(request)
 	if err != nil {
+		stopTimer()
+		cancel()
 		return nil, err
 	}
 
 	// Execute the request
 	fResp, err := t.client.Do(fReq)
+	stopTimer()
+	if timedOut.Load() {
+		if fResp != nil && fResp.Body != nil {
+			_ = fResp.Body.Close()
+		}
+		cancel()
+		return nil, newRequestIdleTimeoutError(t.requestIdleTimeout)
+	}
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
 	// Convert fhttp.Response to net/http.Response
 	resp, err := convertFromFhttpResponse(fResp, req)
 	if err != nil {
+		cancel()
 		// Close the original response body if conversion fails
 		if fResp != nil && fResp.Body != nil {
 			_ = fResp.Body.Close()
 		}
 		return nil, err
+	}
+	if resp.Body != nil && t.requestIdleTimeout > 0 {
+		resp.Body = newIdleTimeoutBody(resp.Body, t.requestIdleTimeout, cancel)
+	} else {
+		cancel()
 	}
 
 	return resp, nil

--- a/internal/tlsclient/transport.go
+++ b/internal/tlsclient/transport.go
@@ -19,6 +19,7 @@ type Transport struct {
 // Ensure Transport implements http.RoundTripper
 var _ http.RoundTripper = (*Transport)(nil)
 
+// DefaultRequestIdleTimeout is the default maximum interval without response data.
 const DefaultRequestIdleTimeout = 30 * time.Second
 
 // NewTransportWithOptions creates a new Transport with the given options
@@ -29,10 +30,7 @@ func NewTransportWithOptions(logger tls_client.Logger, options ...tls_client.Htt
 // NewTransportWithIdleTimeout creates a new Transport with the given request
 // idle timeout and tls-client options. A zero timeout disables idle checks.
 func NewTransportWithIdleTimeout(logger tls_client.Logger, idleTimeout time.Duration, options ...tls_client.HttpClientOption) (*Transport, error) {
-	// A net/http.Transport does not impose a deadline on the entire request.
-	// Match that behavior so large response bodies are not cut off by
-	// tls-client's default 30-second timeout. Callers can still provide an
-	// explicit timeout option, and request contexts continue to cancel requests.
+	// Disable tls-client's total timeout by default; callers may override it.
 	clientOptions := []tls_client.HttpClientOption{tls_client.WithTimeoutSeconds(0)}
 	clientOptions = append(clientOptions, options...)
 

--- a/internal/tlsclient/transport.go
+++ b/internal/tlsclient/transport.go
@@ -97,7 +97,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	// Convert fhttp.Response to net/http.Response
-	resp, err := convertFromFhttpResponse(fResp, req)
+	resp, err := convertFromFhttpResponse(fResp, request)
 	if err != nil {
 		cancel()
 		// Close the original response body if conversion fails

--- a/internal/tlsclient/transport_test.go
+++ b/internal/tlsclient/transport_test.go
@@ -81,10 +81,11 @@ func TestTransportRequestIdleTimeoutWhileWaitingForHeaders(t *testing.T) {
 func TestTransportResponseBodyIdleTimeoutResetsOnProgress(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		flusher, _ := w.(http.Flusher)
 		for _, chunk := range []string{"still ", "making ", "steady ", "progress"} {
 			_, _ = io.WriteString(w, chunk)
-			flusher.Flush()
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
 			time.Sleep(100 * time.Millisecond)
 		}
 	}))
@@ -164,10 +165,20 @@ func TestTransportResponseUsesTransactionContext(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := (&http.Client{Transport: transport}).Do(req)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, resp.Body.Close()) })
 
-	require.NoError(t, resp.Request.Context().Err())
-	require.NoError(t, resp.Body.Close())
+	beforeCloseErr := resp.Request.Context().Err()
+	closeErr := resp.Body.Close()
+	require.NoError(t, beforeCloseErr)
+	require.NoError(t, closeErr)
 	require.ErrorIs(t, resp.Request.Context().Err(), context.Canceled)
 	require.NoError(t, req.Context().Err())
+}
+
+func TestConvertFromFhttpResponseRejectsNilResponse(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+
+	resp, err := convertFromFhttpResponse(nil, req)
+
+	require.EqualError(t, err, "fhttp response is nil")
+	require.Nil(t, resp)
 }

--- a/internal/tlsclient/transport_test.go
+++ b/internal/tlsclient/transport_test.go
@@ -35,7 +35,7 @@ func TestTransportHasNoDefaultRequestTimeout(t *testing.T) {
 	client := &http.Client{Transport: transport}
 	resp, err := client.Get(server.URL)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	t.Cleanup(func() { require.NoError(t, resp.Body.Close()) })
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -58,7 +58,7 @@ func TestTransportResponseBodyIdleTimeout(t *testing.T) {
 
 	resp, err := (&http.Client{Transport: transport}).Get(server.URL)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	t.Cleanup(func() { require.NoError(t, resp.Body.Close()) })
 
 	_, err = io.ReadAll(resp.Body)
 	require.ErrorIs(t, err, ErrRequestIdleTimeout)
@@ -95,7 +95,7 @@ func TestTransportResponseBodyIdleTimeoutResetsOnProgress(t *testing.T) {
 
 	resp, err := (&http.Client{Transport: transport}).Get(server.URL)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	t.Cleanup(func() { require.NoError(t, resp.Body.Close()) })
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestTransportResponseBodyIdleTimeoutCanBeDisabled(t *testing.T) {
 
 	resp, err := (&http.Client{Transport: transport}).Get(server.URL)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	t.Cleanup(func() { require.NoError(t, resp.Body.Close()) })
 
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestTransportHonorsRequestContextCancellation(t *testing.T) {
 
 	resp, err := (&http.Client{Transport: transport}).Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	t.Cleanup(func() { require.NoError(t, resp.Body.Close()) })
 
 	cancel()
 	_, err = io.ReadAll(resp.Body)

--- a/internal/tlsclient/transport_test.go
+++ b/internal/tlsclient/transport_test.go
@@ -150,3 +150,24 @@ func TestTransportHonorsRequestContextCancellation(t *testing.T) {
 	_, err = io.ReadAll(resp.Body)
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+func TestTransportResponseUsesTransactionContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "complete")
+	}))
+	defer server.Close()
+
+	transport, err := NewTransportWithOptions(tls_client.NewNoopLogger())
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	resp, err := (&http.Client{Transport: transport}).Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, resp.Body.Close()) })
+
+	require.NoError(t, resp.Request.Context().Err())
+	require.NoError(t, resp.Body.Close())
+	require.ErrorIs(t, resp.Request.Context().Err(), context.Canceled)
+	require.NoError(t, req.Context().Err())
+}

--- a/internal/tlsclient/transport_test.go
+++ b/internal/tlsclient/transport_test.go
@@ -1,0 +1,152 @@
+package tlsclient
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	tls_client "github.com/bogdanfinn/tls-client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransportHasNoDefaultRequestTimeout(t *testing.T) {
+	oldDefaultTimeout := tls_client.DefaultTimeoutSeconds
+	tls_client.DefaultTimeoutSeconds = 1
+	t.Cleanup(func() {
+		tls_client.DefaultTimeoutSeconds = oldDefaultTimeout
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(1250 * time.Millisecond)
+		_, _ = io.WriteString(w, "complete")
+	}))
+	defer server.Close()
+
+	transport, err := NewTransportWithOptions(tls_client.NewNoopLogger())
+	require.NoError(t, err)
+
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "complete", string(body))
+}
+
+func TestTransportResponseBodyIdleTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(250 * time.Millisecond)
+		_, _ = io.WriteString(w, "too late")
+	}))
+	defer server.Close()
+
+	transport, err := NewTransportWithIdleTimeout(tls_client.NewNoopLogger(), 50*time.Millisecond)
+	require.NoError(t, err)
+
+	resp, err := (&http.Client{Transport: transport}).Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	_, err = io.ReadAll(resp.Body)
+	require.ErrorIs(t, err, ErrRequestIdleTimeout)
+}
+
+func TestTransportRequestIdleTimeoutWhileWaitingForHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(250 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	transport, err := NewTransportWithIdleTimeout(tls_client.NewNoopLogger(), 50*time.Millisecond)
+	require.NoError(t, err)
+
+	_, err = (&http.Client{Transport: transport}).Get(server.URL)
+	require.ErrorIs(t, err, ErrRequestIdleTimeout)
+}
+
+func TestTransportResponseBodyIdleTimeoutResetsOnProgress(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		for _, chunk := range []string{"still ", "making ", "steady ", "progress"} {
+			_, _ = io.WriteString(w, chunk)
+			flusher.Flush()
+			time.Sleep(100 * time.Millisecond)
+		}
+	}))
+	defer server.Close()
+
+	transport, err := NewTransportWithIdleTimeout(tls_client.NewNoopLogger(), 250*time.Millisecond)
+	require.NoError(t, err)
+
+	resp, err := (&http.Client{Transport: transport}).Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "still making steady progress", string(body))
+}
+
+func TestTransportResponseBodyIdleTimeoutCanBeDisabled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(50 * time.Millisecond)
+		_, _ = io.WriteString(w, "complete")
+	}))
+	defer server.Close()
+
+	transport, err := NewTransportWithIdleTimeout(tls_client.NewNoopLogger(), 0)
+	require.NoError(t, err)
+
+	resp, err := (&http.Client{Transport: transport}).Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "complete", string(body))
+}
+
+func TestTransportHonorsRequestContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	transport, err := NewTransportWithOptions(tls_client.NewNoopLogger())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := (&http.Client{Transport: transport}).Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	cancel()
+	_, err = io.ReadAll(resp.Body)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/pkg/fanbox/client.go
+++ b/pkg/fanbox/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hareku/fanbox-dl/internal/ctxval"
+	"github.com/hareku/fanbox-dl/internal/tlsclient"
 	"golang.org/x/net/http2"
 )
 
@@ -194,24 +195,19 @@ func (c *Client) handleAsset(ctx context.Context, post Post, order int, d Downlo
 }
 
 func (c *Client) downloadWithRetry(ctx context.Context, post Post, order int, d Downloadable) error {
-	shouldRetry := func(err error) bool {
-		if errors.Is(err, io.ErrUnexpectedEOF) {
-			return true
-		}
-
-		if _, ok := errors.AsType[*net.OpError](err); ok {
-			return true
-		}
-
-		var goAwayErr *http2.GoAwayError
-		return errors.As(err, &goAwayErr)
-	}
-
 	waitDur := time.Second
-	for range 10 {
+	var lastErr error
+	for attempt := range 10 {
 		if err := c.download(ctx, post, order, d); err != nil {
-			if !shouldRetry(err) {
+			lastErr = err
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if !isRetryableDownloadError(err) {
 				return fmt.Errorf("download error: %w", err)
+			}
+			if attempt == 9 {
+				break
 			}
 
 			slog.ErrorContext(ctx, "Download error, retrying", "error", err, "wait", waitDur)
@@ -222,9 +218,26 @@ func (c *Client) downloadWithRetry(ctx context.Context, post Post, order int, d 
 			}
 			continue
 		}
-		break
+		return nil
 	}
-	return nil
+	return fmt.Errorf("download error after retries: %w", lastErr)
+}
+
+func isRetryableDownloadError(err error) bool {
+	if errors.Is(err, tlsclient.ErrRequestIdleTimeout) {
+		return true
+	}
+
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	if _, ok := errors.AsType[*net.OpError](err); ok {
+		return true
+	}
+
+	var goAwayErr *http2.GoAwayError
+	return errors.As(err, &goAwayErr)
 }
 
 var ErrStatusForbidden = errors.New("status code 403")

--- a/pkg/fanbox/download_test.go
+++ b/pkg/fanbox/download_test.go
@@ -1,0 +1,14 @@
+package fanbox
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hareku/fanbox-dl/internal/tlsclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestIdleTimeoutIsRetryable(t *testing.T) {
+	err := fmt.Errorf("save a file: %w", tlsclient.ErrRequestIdleTimeout)
+	require.True(t, isRetryableDownloadError(err))
+}


### PR DESCRIPTION
## Summary

- disable `tls-client`'s 30-second whole-request timeout
- add `--request-idle-timeout`, defaulting to 30 seconds
- reset the idle timeout whenever response data is received
- retry downloads that fail because of the idle timeout
- prevent duplicate retries between `retryablehttp` and the download retry loop
- return an error when all download retries are exhausted

## Background

`tls-client` applies its default timeout to the entire request lifecycle, including reading the response body. Large or slow downloads can therefore fail after 30 seconds even while data is still being received.

This change replaces that total-duration limit with an inactivity timeout. A download can take any amount of total time as long as it continues receiving data. Setting `--request-idle-timeout 0` disables the inactivity timeout.

This overlaps with #75 because both changes address `tls-client`'s default request timeout. However, #75 makes the total request timeout configurable, while this PR uses an idle timeout so that slow but progressing downloads are not terminated solely because of their total duration.

Timed-out downloads are retried from the beginning. Resuming partial downloads with HTTP Range requests remains outside the scope of this change.

## Testing

- `go test -count=1 ./...`
- `go vet ./...`
- `golangci-lint run`
- `go build ./cmd/fanbox-dl`

Closes #91